### PR TITLE
Crude way to work in the new 3.5GPT-turbo end point

### DIFF
--- a/Source/OpenAIAPI/Private/OpenAICallGPT.cpp
+++ b/Source/OpenAIAPI/Private/OpenAICallGPT.cpp
@@ -92,7 +92,7 @@ void UOpenAICallGPT::Activate()
 	}
 
 	// convert parameters to strings
-	FString tempPrompt = settings.startSequence + prompt + settings.injectStartText;
+	FString tempPrompt = [settings.startSequence + prompt + settings.injectStartText];
 	FString tempHeader = "Bearer ";
 	tempHeader += _apiKey;
 
@@ -104,7 +104,8 @@ void UOpenAICallGPT::Activate()
 
 	//build payload
 	TSharedPtr<FJsonObject> _payloadObject = MakeShareable(new FJsonObject());
-	_payloadObject->SetStringField(TEXT("prompt"), tempPrompt);
+	_payloadObject->SetStringField(TEXT("messages"), tempPrompt);
+	_payloadObject->SetStringField(TEXT("model"), apiMethod);
 	_payloadObject->SetNumberField(TEXT("max_tokens"), settings.maxTokens);
 	_payloadObject->SetNumberField(TEXT("temperature"), FMath::Clamp(settings.temperature, 0.0f, 1.0f));
 	_payloadObject->SetNumberField(TEXT("top_p"), FMath::Clamp(settings.topP, 0.0f, 1.0f));

--- a/Source/OpenAIAPI/Private/OpenAICallGPT.cpp
+++ b/Source/OpenAIAPI/Private/OpenAICallGPT.cpp
@@ -63,7 +63,7 @@ void UOpenAICallGPT::Activate()
 	switch (engine)
 	{
 	case EOAEngineType::DAVINCI:
-			apiMethod = "davinci";
+			apiMethod = "gpt-3.5-turbo";
 	break;
 	case EOAEngineType::CURIE:
 			apiMethod = "curie";
@@ -97,7 +97,7 @@ void UOpenAICallGPT::Activate()
 	tempHeader += _apiKey;
 
 	// set headers
-	FString url = FString::Printf(TEXT("https://api.openai.com/v1/engines/%s/completions"), *apiMethod);
+	FString url = FString::Printf(TEXT("https://api.openai.com/v1/chat/completions"), *apiMethod); //Crude but Lock on davinci and you will use gpt3.5
 	HttpRequest->SetURL(url);
 	HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
 	HttpRequest->SetHeader(TEXT("Authorization"), tempHeader);


### PR DESCRIPTION
This is a extremely rough hack to make it work so I can move on with a project. Ultimately you will need a new settings option to toggle the endpoint to include 'chat'/completions and back to the old /completions endpoint. Just need to stay on davinci in the editor and not use any other setting. The other models won't work. Only 3.5 on the Davinci setting